### PR TITLE
Update _extension.yml to remove reference to abstract.tex

### DIFF
--- a/_extensions/wiley-njd/_extension.yml
+++ b/_extensions/wiley-njd/_extension.yml
@@ -39,7 +39,6 @@ contributes:
         - "partials/hyperref.tex"
         - "partials/natbib.tex"
         - "partials/box.tex"
-        - "partials/abstract.tex"
         - "partials/title.tex"
       format-resources:
         - wiley-njd-v5/WileyNJDv5.cls


### PR DESCRIPTION
With the new Quarto update, missing partial files raise an error. Since `abstract.tex` wasn't present in the directory, it was raising an error. After removing the reference to it in `_extension.yml`, the error is gone.